### PR TITLE
Added the missing option to pass context folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ What's working:
         (add-to-list 'load-path "/path/to/augment.vim.git/emacs/")
         (require 'lsp-augment)
         (add-to-list 'lsp-language-id-configuration '(emacs-lisp-mode . "augment"))
+        ;; if you have additional directories that you want to add to make
+        ;; Augment Code aware of them, you'd set:
+        (setq lsp-augment-additional-context-folders
+          '("~/projects/shared-library"
+           "~/projects/core-framework\"))
         ```
 
 1. Start emacs and log into your Augment account via `M-x lsp-augment-signin`

--- a/emacs/lsp-augment.el
+++ b/emacs/lsp-augment.el
@@ -31,16 +31,7 @@
 These directories help Augment provide better assistance by giving it
 access to related code and context. For example, if you're working on a
 module that depends on another project, you might want to add that
-project's directory here.
-
-You'd use it like so:
-
-  (setq lsp-augment-additional-context-folders
-        '(\"~/projects/shared-library\"
-          \"~/projects/core-framework\"))
-
-Note: you'd remove those backslashes before the double quotes in your
-configuration."
+project's directory here."
   :group 'lsp-augment
   :type '(repeat directory))
 

--- a/emacs/lsp-augment.el
+++ b/emacs/lsp-augment.el
@@ -183,6 +183,12 @@ Returns a plist with status information from the server."
                     :name (file-name-nondirectory (directory-file-name folder))))
             lsp-augment-additional-context-folders)))
 
+(defun lsp-augment--custom-capabilities ()
+  "Add workspace folders to initialization request."
+  (let ((folders (lsp-augment--get-workspace-folders)))
+    (when folders
+      `(:workspaceFolders ,folders))))
+
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-augment--server-command)
@@ -192,7 +198,7 @@ Returns a plist with status information from the server."
   :add-on? t
   :completion-in-comments? t
   :initialization-options #'lsp-augment--server-initialization-options
-  :workspace-folders #'lsp-augment--get-workspace-folders
+  :custom-capabilities #'lsp-augment--custom-capabilities
   :notification-handlers (lsp-ht
 			  ("augment/chatChunk" #'lsp-augment--chat-chunk-handler))))
 


### PR DESCRIPTION
The Vim plugin has this option and this is an attempt to stay feature complete on Emacs side.

It allows the user to set an option of additional directories that should be passed in on initialization, in order to give extra context to Augment Code service.

See the Lua code for usage:
 
https://github.com/dotemacs/augment.vim/blob/feature%2Fadd-additional-context-folders/lua/augment.lua#L38-L41