### PR TITLE
use gfm-view-mode instead of markdown-view-mode

### DIFF
--- a/emacs/lsp-augment.el
+++ b/emacs/lsp-augment.el
@@ -85,8 +85,8 @@ Enter the authentication code: " (lsp-get signin-response :url)))))
   "Append text to the Augment chat buffer."
   (let ((buf-name "*Augment Chat History*"))
     (with-current-buffer (get-buffer-create buf-name)
-      (unless (derived-mode-p 'markdown-view-mode)
-	(markdown-view-mode))
+      (unless (derived-mode-p 'gfm-view-mode)
+	(gfm-view-mode))
       (save-excursion
 	(let ((inhibit-read-only t))
 	  (goto-char (point-max))


### PR DESCRIPTION
gfm-mode is handling quad-backtick fencing correctly when presenting c++ code (at least in text mode emacs).

E.g. underscore in 'my_string' class name is swallowed and interpreted as highlight formatting.

markdown-view-mode:

The my_string assignment operators are defined in the cc.cc file:

````cpp path=cc.cc mode=EXCERPT
mystring& operator=(mystring const & lhs)
````

gfm-view-mode:

The my_string assignment operators are defined in the cc.cc file:

````cpp path=cc.cc mode=EXCERPT
my_string& operator=(my_string const & lhs)
````